### PR TITLE
fix `self > other` to be `other < self`

### DIFF
--- a/swift/src/string/cmp.rs
+++ b/swift/src/string/cmp.rs
@@ -58,7 +58,7 @@ impl PartialOrd for String {
 
     #[inline]
     fn gt(&self, other: &Self) -> bool {
-        other > self
+        other < self
     }
 
     #[inline]


### PR DESCRIPTION
Looks like a typo.